### PR TITLE
feat: implement Go trading bot with arbitrage logic

### DIFF
--- a/go-impl/arbitrage.go
+++ b/go-impl/arbitrage.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// ArbitrageConfig holds arbitrage trading configuration
+type ArbitrageConfig struct {
+	HuobiSymbol string // e.g., "nasusdt"
+	GateSymbol  string // e.g., "NAS_USDT"
+	MinProfit   float64
+	TradeAmount float64
+	CheckInterval int // milliseconds
+}
+
+// ArbitrageTrader handles the arbitrage trading logic
+type ArbitrageTrader struct {
+	config       *ArbitrageConfig
+	huobiClient  *HuobiClient
+	gateClient   *GateClient
+	emailSender  *EmailSender
+	counter      int
+	times        int
+	mu           sync.Mutex
+	ctx          context.Context
+}
+
+// NewArbitrageTrader creates a new arbitrage trader
+func NewArbitrageTrader(config *ArbitrageConfig, huobi *HuobiClient, gate *GateClient, email *EmailSender) *ArbitrageTrader {
+	return &ArbitrageTrader{
+		config:      config,
+		huobiClient: huobi,
+		gateClient:  gate,
+		emailSender: email,
+		counter:     0,
+		times:       0,
+	}
+}
+
+// Start starts the arbitrage trading loop
+func (t *ArbitrageTrader) Start(ctx context.Context) error {
+	log.Printf("[Arbitrage] Starting trader for %s/%s", t.config.HuobiSymbol, t.config.GateSymbol)
+
+	ticker := time.NewTicker(time.Duration(t.config.CheckInterval) * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			t.executeArbitrage()
+		}
+	}
+}
+
+func (t *ArbitrageTrader) executeArbitrage() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.times++
+
+	// Fetch order books from both exchanges
+	hbOrderBook, err := t.huobiClient.FetchOrderBook(t.config.HuobiSymbol, 5)
+	if err != nil {
+		log.Printf("[Arbitrage] Failed to fetch Huobi orderbook: %v", err)
+		return
+	}
+
+	gateOrderBook, err := t.gateClient.FetchOrderBook(t.config.GateSymbol, 5)
+	if err != nil {
+		log.Printf("[Arbitrage] Failed to fetch Gate orderbook: %v", err)
+		return
+	}
+
+	// Get best prices
+	// Huobi: bid=买价(买一), ask=卖价(卖一)
+	// Gate: bid=买价, ask=卖价
+	var hbBidPrice, hbAskPrice, gateBidPrice, gateAskPrice float64
+
+	if len(hbOrderBook.Bids) > 0 {
+		hbBidPrice, _ = strconv.ParseFloat(fmt.Sprintf("%v", hbOrderBook.Bids[0][0]), 64)
+	}
+	if len(hbOrderBook.Asks) > 0 {
+		hbAskPrice, _ = strconv.ParseFloat(fmt.Sprintf("%v", hbOrderBook.Asks[0][0]), 64)
+	}
+	if len(gateOrderBook.Bids) > 0 {
+		gateBidPrice, _ = strconv.ParseFloat(fmt.Sprintf("%v", gateOrderBook.Bids[0][0]), 64)
+	}
+	if len(gateOrderBook.Asks) > 0 {
+		gateAskPrice, _ = strconv.ParseFloat(fmt.Sprintf("%v", gateOrderBook.Asks[0][0]), 64)
+	}
+
+	// Get amounts
+	hbBidAmount := 0.0
+	hbAskAmount := 0.0
+	gateBidAmount := 0.0
+	gateAskAmount := 0.0
+
+	if len(hbOrderBook.Bids) > 0 {
+		hbBidAmount, _ = strconv.ParseFloat(fmt.Sprintf("%v", hbOrderBook.Bids[0][1]), 64)
+	}
+	if len(hbOrderBook.Asks) > 0 {
+		hbAskAmount, _ = strconv.ParseFloat(fmt.Sprintf("%v", hbOrderBook.Asks[0][1]), 64)
+	}
+	if len(gateOrderBook.Bids) > 0 {
+		gateBidAmount, _ = strconv.ParseFloat(fmt.Sprintf("%v", gateOrderBook.Bids[0][1]), 64)
+	}
+	if len(gateOrderBook.Asks) > 0 {
+		gateAskAmount, _ = strconv.ParseFloat(fmt.Sprintf("%v", gateOrderBook.Asks[0][1]), 64)
+	}
+
+	log.Printf("[Arbitrage] Huobi: bid=%.8f(%.4f) ask=%.8f(%.4f), Gate: bid=%.8f(%.4f) ask=%.8f(%.4f)",
+		hbBidPrice, hbBidAmount, hbAskPrice, hbAskAmount,
+		gateBidPrice, gateBidAmount, gateAskPrice, gateAskAmount)
+
+	// Strategy 1: Buy on Gate, Sell on Huobi
+	// Gate bid price < Huobi ask price -> buy on Gate, sell on Huobi
+	profit1 := hbAskPrice - gateBidPrice
+	if profit1 > t.config.MinProfit && gateBidAmount > t.config.TradeAmount && hbAskAmount > t.config.TradeAmount {
+		log.Printf("[Arbitrage] Opportunity 1: Buy on Gate @ %.8f, Sell on Huobi @ %.8f, Profit: %.8f",
+			gateBidPrice, hbAskPrice, profit1)
+		t.executeTrade(gateBidPrice, hbAskPrice, "gate_to_huobi", profit1)
+		return
+	}
+
+	// Strategy 2: Buy on Huobi, Sell on Gate
+	// Huobi bid price < Gate ask price -> buy on Huobi, sell on Gate
+	profit2 := gateAskPrice - hbBidPrice
+	if profit2 > t.config.MinProfit && hbBidAmount > t.config.TradeAmount && gateAskAmount > t.config.TradeAmount {
+		log.Printf("[Arbitrage] Opportunity 2: Buy on Huobi @ %.8f, Sell on Gate @ %.8f, Profit: %.8f",
+			hbBidPrice, gateAskPrice, profit2)
+		t.executeTrade(hbBidPrice, gateAskPrice, "huobi_to_gate", profit2)
+		return
+	}
+}
+
+func (t *ArbitrageTrader) executeTrade(buyPrice, sellPrice float64, direction string, profit float64) {
+	amount := t.config.TradeAmount
+	baseSymbol := t.config.HuobiSymbol[:len(t.config.HuobiSymbol)-4] // remove "usdt"
+	quoteSymbol := "usdt"
+
+	var buyErr, sellErr error
+
+	if direction == "gate_to_huobi" {
+		// Buy on Gate, Sell on Huobi
+		_, buyErr = t.gateClient.CreateLimitBuyOrder(t.config.GateSymbol, amount, buyPrice)
+		if buyErr == nil {
+			_, sellErr = t.huobiClient.CreateLimitSellOrder(t.config.HuobiSymbol, amount, sellPrice)
+		}
+	} else {
+		// Buy on Huobi, Sell on Gate
+		_, buyErr = t.huobiClient.CreateLimitBuyOrder(t.config.HuobiSymbol, amount, buyPrice)
+		if buyErr == nil {
+			_, sellErr = t.gateClient.CreateLimitSellOrder(t.config.GateSymbol, amount, sellPrice)
+		}
+	}
+
+	t.counter++
+
+	if buyErr != nil || sellErr != nil {
+		log.Printf("[Arbitrage] Trade failed: buy_err=%v, sell_err=%v", buyErr, sellErr)
+		subject := fmt.Sprintf("[搬砖] 交易失败! 方向: %s", direction)
+		content := fmt.Sprintf("买入价: %.8f, 卖出价: %.8f, 利润: %.8f\n错误: %v / %v",
+			buyPrice, sellPrice, profit, buyErr, sellErr)
+		t.emailSender.Send(subject, content)
+	} else {
+		log.Printf("[Arbitrage] Trade executed successfully! Direction: %s, Profit: %.8f", direction, profit)
+		subject := fmt.Sprintf("[搬砖] 交易成功! 方向: %s", direction)
+		content := fmt.Sprintf("买入价: %.8f, 卖出价: %.8f, 数量: %.4f, 利润: %.8f",
+			buyPrice, sellPrice, amount, profit)
+		t.emailSender.Send(subject, content)
+	}
+
+	log.Printf("[Arbitrage] %s -- 已搬砖次数: %d -- 检测到可搬砖次数: %d",
+		time.Now().Format("2006-01-02 15:04:05"), t.counter, t.times)
+}
+
+// CheckBalance checks account balances
+func (t *ArbitrageTrader) CheckBalance() (hbNAS, hbUSDT, gateNAS, gateUSDT float64, err error) {
+	// Get Huobi balance
+	hbBalance, err := t.huobiClient.FetchBalance()
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+
+	for _, b := range hbBalance.List {
+		if b.Currency == "nas" && b.Type == "trade" {
+			hbNAS, _ = strconv.ParseFloat(b.Balance, 64)
+		}
+		if b.Currency == "usdt" && b.Type == "trade" {
+			hbUSDT, _ = strconv.ParseFloat(b.Balance, 64)
+		}
+	}
+
+	// Get Gate balance
+	gateBalance, err := t.gateClient.FetchBalance()
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+
+	if nas, ok := gateBalance.Available["NAS"]; ok {
+		gateNAS, _ = strconv.ParseFloat(nas, 64)
+	}
+	if usdt, ok := gateBalance.Available["USDT"]; ok {
+		gateUSDT, _ = strconv.ParseFloat(usdt, 64)
+	}
+
+	return hbNAS, hbUSDT, gateNAS, gateUSDT, nil
+}
+
+// round rounds a float to specified decimal places
+func round(x float64, decimals int) float64 {
+	p := math.Pow10(decimals)
+	return math.Round(x*p) / p
+}

--- a/go-impl/gate.go
+++ b/go-impl/gate.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+// GateClient handles Gate.io API interactions
+type GateClient struct {
+	accessKey string
+	secretKey string
+}
+
+// NewGateClient creates a new Gate.io client from environment variables
+func NewGateClient() *GateClient {
+	return &GateClient{
+		accessKey: os.Getenv("GATE_ACCESS_KEY"),
+		secretKey: os.Getenv("GATE_SECRET_KEY"),
+	}
+}
+
+// GateOrderBook represents Gate.io order book data
+type GateOrderBook struct {
+	Bids [][]interface{} `json:"bids"`
+	Asks [][]interface{} `json:"asks"`
+}
+
+// GateOrderBookResponse represents the API response for order book
+type GateOrderBookResponse struct {
+	Method string        `json:"method"`
+	Params GateOrderBook `json:"params"`
+	ID     int           `json:"id"`
+}
+
+// GateBalance represents balance information
+type GateBalance struct {
+	Available map[string]string `json:"available"`
+	Locked    map[string]string `json:"locked"`
+}
+
+// GateBalanceResponse represents the API response for balance
+type GateBalanceResponse struct {
+	Method string       `json:"method"`
+	Params []interface{} `json:"params"`
+	ID     int          `json:"id"`
+}
+
+// GateOrder represents order information
+type GateOrder struct {
+	ID        string `json:"id"`
+	Currency  string `json:"currency"`
+	Type      string `json:"type"`
+	Side      string `json:"side"`
+	Amount    string `json:"amount"`
+	Price     string `json:"price"`
+	Status    string `json:"status"`
+	CreatedAt int64  `json:"create_time"`
+}
+
+// GateOrderResponse represents the API response for order
+type GateOrderResponse struct {
+	ID     int        `json:"id"`
+	Result bool       `json:"result"`
+	Order  *GateOrder `json:"order"`
+}
+
+// sign generates HMAC-SHA512 signature for Gate.io API
+func (c *GateClient) sign(params map[string]string, queryString string) string {
+	signString := queryString
+	h := hmac.New(sha512.New, []byte(c.secretKey))
+	h.Write([]byte(signString))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// FetchOrderBook retrieves order book for a trading pair
+func (c *GateClient) FetchOrderBook(symbol string, limit int) (*GateOrderBook, error) {
+	url := fmt.Sprintf("https://api.gateio.ws/api2/1/orderBook/%s", symbol)
+
+	if limit > 0 {
+		url += fmt.Sprintf("?limit=%d", limit)
+	}
+
+	resp, err := fasthttp.Get(nil, url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Release()
+
+	var result GateOrderBook
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// FetchBalance retrieves account balance
+func (c *GateClient) FetchBalance() (*GateBalance, error) {
+	timestamp := time.Now().Unix()
+
+	params := map[string]string{
+		"method": "balance_info",
+		"api_key": c.accessKey,
+	}
+
+	// Build query string
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var paramStrs []string
+	for _, k := range keys {
+		paramStrs = append(paramStrs, k+"="+params[k])
+	}
+	queryString := "?" + strings.Join(paramStrs, "&") + fmt.Sprintf("&sign=%s&timestamp=%d", c.sign(params, queryString), timestamp)
+
+	url := "https://api.gateio.ws/api2/1/spot/balance_info" + queryString
+
+	req := fasthttp.NewRequest()
+	req.SetRequestURI(url)
+	req.Header.SetMethod("POST")
+
+	resp, err := fasthttp.Do(req, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Release()
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, err
+	}
+
+	available := make(map[string]string)
+	if avail, ok := result["available"].(map[string]interface{}); ok {
+		for k, v := range avail {
+			available[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	locked := make(map[string]string)
+	if lock, ok := result["locked"].(map[string]interface{}); ok {
+		for k, v := range lock {
+			locked[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	return &GateBalance{
+		Available: available,
+		Locked:    locked,
+	}, nil
+}
+
+// CreateMarketBuyOrder creates a market buy order
+func (c *GateClient) CreateMarketBuyOrder(symbol string, amount float64) (*GateOrder, error) {
+	return c.createOrder(symbol, "buy", "market", amount, 0)
+}
+
+// CreateMarketSellOrder creates a market sell order
+func (c *GateClient) CreateMarketSellOrder(symbol string, amount float64) (*GateOrder, error) {
+	return c.createOrder(symbol, "sell", "market", amount, 0)
+}
+
+// CreateLimitBuyOrder creates a limit buy order
+func (c *GateClient) CreateLimitBuyOrder(symbol string, amount float64, price float64) (*GateOrder, error) {
+	return c.createOrder(symbol, "buy", "limit", amount, price)
+}
+
+// CreateLimitSellOrder creates a limit sell order
+func (c *GateClient) CreateLimitSellOrder(symbol string, amount float64, price float64) (*GateOrder, error) {
+	return c.createOrder(symbol, "sell", "limit", amount, price)
+}
+
+// createOrder creates an order on Gate.io
+func (c *GateClient) createOrder(symbol, side, orderType string, amount float64, price float64) (*GateOrder, error) {
+	timestamp := time.Now().Unix()
+
+	params := map[string]string{
+		"currency":  symbol,
+		"type":      orderType,
+		"side":      side,
+		"amount":    fmt.Sprintf("%f", amount),
+		"api_key":   c.accessKey,
+	}
+
+	if price > 0 {
+		params["price"] = fmt.Sprintf("%f", price)
+	}
+
+	// Build query string
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var paramStrs []string
+	for _, k := range keys {
+		paramStrs = append(paramStrs, k+"="+params[k])
+	}
+	queryString := strings.Join(paramStrs, "&")
+	queryString += fmt.Sprintf("&sign=%s&timestamp=%d", c.sign(params, queryString), timestamp)
+
+	url := "https://api.gateio.ws/api2/1/spot/orders"
+
+	req := fasthttp.NewRequest()
+	req.SetRequestURI(url)
+	req.Header.SetMethod("POST")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBody(queryString)
+
+	resp, err := fasthttp.Do(req, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Release()
+
+	var result GateOrderResponse
+	if err := json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, err
+	}
+
+	if !result.Result {
+		return nil, fmt.Errorf("order creation failed: %s", string(resp.Body()))
+	}
+
+	return result.Order, nil
+}

--- a/go-impl/main.go
+++ b/go-impl/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 )
 
@@ -13,47 +14,67 @@ import (
 type Config struct {
 	HuobiAccessKey string
 	HuobiSecretKey string
+	GateAccessKey  string
+	GateSecretKey  string
 	SMTPHost       string
 	SMTPPort       int
 	SMTPUsername   string
 	SMTPPassword   string
 	EmailFrom      string
 	EmailTo        string
-	Symbols        []string
-	PriceHigh      float64
-	PriceLow       float64
-	PriceInterval  int
+
+	// Arbitrage config
+	HuobiSymbol    string
+	GateSymbol     string
+	MinProfit      float64
+	TradeAmount    float64
+	CheckInterval  int // milliseconds
 	WSEnabled      bool
 	PriceEnabled   bool
+	ArbitrageEnabled bool
 }
 
 func loadConfig() *Config {
-	symbolsStr := os.Getenv("SYMBOLS")
-	symbols := []string{}
-	if symbolsStr != "" {
-		symbols = []string{symbolsStr} // For single symbol, split by comma if needed
+	checkInterval := 500 // default 500ms
+	if iv := os.Getenv("ARBITRAGE_CHECK_INTERVAL"); iv != "" {
+		if v, err := strconv.Atoi(iv); err == nil {
+			checkInterval = v
+		}
 	}
 
-	priceInterval := 60
-	if iv := os.Getenv("PRICE_INTERVAL"); iv != "" {
-		fmt.Sscanf(iv, "%d", &priceInterval)
+	minProfit := 0.001 // default 0.001 USDT
+	if mp := os.Getenv("MIN_PROFIT"); mp != "" {
+		if v, err := strconv.ParseFloat(mp, 64); err == nil {
+			minProfit = v
+		}
+	}
+
+	tradeAmount := 2.0 // default 2 NAS
+	if ta := os.Getenv("TRADE_AMOUNT"); ta != "" {
+		if v, err := strconv.ParseFloat(ta, 64); err == nil {
+			tradeAmount = v
+		}
 	}
 
 	return &Config{
-		HuobiAccessKey: os.Getenv("HUOBI_ACCESS_KEY"),
-		HuobiSecretKey: os.Getenv("HUOBI_SECRET_KEY"),
-		SMTPHost:       os.Getenv("SMTP_HOST"),
-		SMTPPort:       587,
-		SMTPUsername:   os.Getenv("SMTP_USERNAME"),
-		SMTPPassword:   os.Getenv("SMTP_PASSWORD"),
-		EmailFrom:      os.Getenv("EMAIL_FROM"),
-		EmailTo:        os.Getenv("EMAIL_TO"),
-		Symbols:        symbols,
-		PriceHigh:      0,
-		PriceLow:       0,
-		PriceInterval:  priceInterval,
-		WSEnabled:      os.Getenv("WS_ENABLED") == "true",
-		PriceEnabled:   os.Getenv("PRICE_NOTICE_ENABLED") == "true",
+		HuobiAccessKey:    os.Getenv("HUOBI_ACCESS_KEY"),
+		HuobiSecretKey:    os.Getenv("HUOBI_SECRET_KEY"),
+		GateAccessKey:     os.Getenv("GATE_ACCESS_KEY"),
+		GateSecretKey:     os.Getenv("GATE_SECRET_KEY"),
+		SMTPHost:          os.Getenv("SMTP_HOST"),
+		SMTPPort:          587,
+		SMTPUsername:      os.Getenv("SMTP_USERNAME"),
+		SMTPPassword:      os.Getenv("SMTP_PASSWORD"),
+		EmailFrom:         os.Getenv("EMAIL_FROM"),
+		EmailTo:           os.Getenv("EMAIL_TO"),
+		HuobiSymbol:       os.Getenv("HUOBI_SYMBOL"),
+		GateSymbol:        os.Getenv("GATE_SYMBOL"),
+		MinProfit:         minProfit,
+		TradeAmount:       tradeAmount,
+		CheckInterval:     checkInterval,
+		WSEnabled:         os.Getenv("WS_ENABLED") == "true",
+		PriceEnabled:      os.Getenv("PRICE_NOTICE_ENABLED") == "true",
+		ArbitrageEnabled:  os.Getenv("ARBITRAGE_ENABLED") == "true",
 	}
 }
 
@@ -61,10 +82,15 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("[move-bricks] ")
 
+	log.Println("=== Go Trading Bot Starting ===")
+
 	config := loadConfig()
 
 	// Create Huobi client
 	huobi := NewHuobiClient()
+
+	// Create Gate client
+	gate := NewGateClient()
 
 	// Create email sender
 	emailConfig := DefaultEmailConfig()
@@ -83,6 +109,30 @@ func main() {
 		cancel()
 	}()
 
+	// Check and display balances
+	log.Println("Checking account balances...")
+	trader := &ArbitrageTrader{
+		huobiClient: huobi,
+		gateClient:  gate,
+	}
+	hbNAS, hbUSDT, gateNAS, gateUSDT, err := trader.CheckBalance()
+	if err != nil {
+		log.Printf("Failed to fetch balances: %v", err)
+	} else {
+		log.Printf("Huobi - NAS: %.4f, USDT: %.4f", hbNAS, hbUSDT)
+		log.Printf("Gate   - NAS: %.4f, USDT: %.4f", gateNAS, gateUSDT)
+
+		// Check if balances are sufficient
+		if hbNAS < 1 {
+			log.Println("WARNING: Huobi NAS balance insufficient!")
+			emailSender.Send("火币NAS余额不足!", fmt.Sprintf("火币NAS余额: %.4f", hbNAS))
+		}
+		if gateNAS < 1 {
+			log.Println("WARNING: Gate NAS balance insufficient!")
+			emailSender.Send("Gate NAS余额不足!", fmt.Sprintf("Gate NAS余额: %.4f", gateNAS))
+		}
+	}
+
 	// Start WebSocket listener if enabled
 	if config.WSEnabled {
 		wsClient := NewHuobiWSClient(func(symbol string, kline KLine) {
@@ -93,9 +143,9 @@ func main() {
 			log.Printf("WebSocket error: %v", err)
 		} else {
 			// Subscribe to symbols
-			for _, symbol := range config.Symbols {
-				if err := wsClient.Subscribe(symbol, "1min"); err != nil {
-					log.Printf("Subscribe error for %s: %v", symbol, err)
+			if config.HuobiSymbol != "" {
+				if err := wsClient.Subscribe(config.HuobiSymbol, "1min"); err != nil {
+					log.Printf("Subscribe error for %s: %v", config.HuobiSymbol, err)
 				}
 			}
 			go wsClient.WaitForSignal()
@@ -103,17 +153,32 @@ func main() {
 	}
 
 	// Start price monitoring if enabled
-	if config.PriceEnabled && len(config.Symbols) > 0 {
+	if config.PriceEnabled && config.HuobiSymbol != "" {
 		noticeConfig := &PriceNoticeConfig{
-			Symbols:       config.Symbols,
-			HighThreshold: config.PriceHigh,
-			LowThreshold:  config.PriceLow,
-			CheckInterval: config.PriceInterval,
+			Symbols:       []string{config.HuobiSymbol},
+			HighThreshold: 0,
+			LowThreshold:  0,
+			CheckInterval: config.CheckInterval,
 			Enabled:       true,
 		}
 		priceChecker := NewPriceChecker(noticeConfig, emailSender, huobi)
 		if err := priceChecker.Start(ctx); err != nil {
 			log.Printf("Price monitor error: %v", err)
+		}
+	}
+
+	// Start arbitrage trading if enabled
+	if config.ArbitrageEnabled && config.HuobiSymbol != "" && config.GateSymbol != "" {
+		arbitrageConfig := &ArbitrageConfig{
+			HuobiSymbol:   config.HuobiSymbol,
+			GateSymbol:    config.GateSymbol,
+			MinProfit:     config.MinProfit,
+			TradeAmount:   config.TradeAmount,
+			CheckInterval: config.CheckInterval,
+		}
+		arbitrageTrader := NewArbitrageTrader(arbitrageConfig, huobi, gate, emailSender)
+		if err := arbitrageTrader.Start(ctx); err != nil {
+			log.Printf("Arbitrage error: %v", err)
 		}
 	}
 


### PR DESCRIPTION
- Add Gate.io client (gate.go) for exchange interactions
- Add arbitrage trading logic (arbitrage.go) for cross-exchange trading
- Update main.go with arbitrage config and balance checking
- Replaces Python move_bricks.py with Go implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds automated cross-exchange order placement (live trading) and new Gate.io signed API integration; bugs in pricing/amount logic or signing could lead to unintended trades or fund loss.
> 
> **Overview**
> Introduces a Gate.io integration (`gate.go`) with signed balance retrieval and market/limit order creation, plus public order book fetching.
> 
> Adds an `ArbitrageTrader` (`arbitrage.go`) that polls Huobi and Gate order books on an interval, detects simple two-way price spreads above `MIN_PROFIT`, and executes paired limit trades with email notifications on success/failure.
> 
> Updates `main.go` to load new env-based arbitrage configuration (`HUOBI_SYMBOL`, `GATE_SYMBOL`, `ARBITRAGE_ENABLED`, etc.), perform startup balance checks with warning emails, and optionally start the arbitrage loop (and adjusts WS/price monitoring to use the single configured symbol).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 262d341f996d42ef1d7e1f51b73d0818dfe62f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->